### PR TITLE
[ADD] shopQueryHandler의 searchByDetailCategoryWithIn 테스트 완료

### DIFF
--- a/adapter/router-common/src/main/kotlin/team/bakkas/applicationcommon/advice/GlobalErrorAttributes.kt
+++ b/adapter/router-common/src/main/kotlin/team/bakkas/applicationcommon/advice/GlobalErrorAttributes.kt
@@ -13,6 +13,7 @@ import team.bakkas.common.exceptions.shop.ShopBranchInfoInvalidException
 import team.bakkas.common.exceptions.shopReview.ShopReviewListInvalidException
 import team.bakkas.common.error.ErrorCode
 import team.bakkas.common.exceptions.shop.CategoryNotFoundException
+import team.bakkas.common.exceptions.shop.DetailCategoryNotFoundException
 import team.bakkas.common.exceptions.shop.ShopNotFoundException
 import team.bakkas.common.exceptions.shopReview.ShopReviewNotFoundException
 
@@ -42,6 +43,11 @@ class GlobalErrorAttributes : DefaultErrorAttributes() {
                 map["error_code"] = ErrorCode.INVALID_INFO
             }
             is CategoryNotFoundException -> {
+                map["default_message"] = throwable.message
+                map["error"] = ErrorCode.REQUEST_PARAM_ERROR
+                map["error_code"] = ErrorCode.REQUEST_PARAM_ERROR
+            }
+            is DetailCategoryNotFoundException -> {
                 map["default_message"] = throwable.message
                 map["error"] = ErrorCode.REQUEST_PARAM_ERROR
                 map["error_code"] = ErrorCode.REQUEST_PARAM_ERROR

--- a/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandler.kt
+++ b/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandler.kt
@@ -14,9 +14,11 @@ import team.bakkas.applicationquery.grpc.client.GrpcShopSearchClient
 import team.bakkas.common.ResultFactory
 import team.bakkas.common.exceptions.RequestParamLostException
 import team.bakkas.common.exceptions.shop.CategoryNotFoundException
+import team.bakkas.common.exceptions.shop.DetailCategoryNotFoundException
 import team.bakkas.common.exceptions.shop.ShopNotFoundException
 import team.bakkas.domainquery.service.ifs.ShopQueryService
 import team.bakkas.dynamo.shop.vo.category.Category
+import team.bakkas.dynamo.shop.vo.category.DetailCategory
 
 /** Shop에 대한 Query logic을 처리하는 Handler class
  * @param shopQueryService shop에 대한 Service 로직들을 저장한 컨포넌트
@@ -36,7 +38,6 @@ class ShopQueryHandler(
             throw RequestParamLostException("Empty query parameter")
         }
 
-        // shop이 발견되지 않으면 ShopNotFoundException을 일으킨다
         val shop = shopQueryService.findShopById(shopId) ?: throw ShopNotFoundException("Shop is not found!!")
 
         if (shop.deletedAt != null) {
@@ -66,6 +67,7 @@ class ShopQueryHandler(
     }
 
     // TODO 반경 검색, 카테고리별 검색, 세부 카테고리별 검색, 가게 이름 기반 검색 구현
+    // category 기반의 반경 검색
     suspend fun searchByCategoryWithIn(request: ServerRequest): ServerResponse = coroutineScope {
         val category = request.queryParamOrNull("category") ?: throw RequestParamLostException("category is lost")
         val latitude = request.queryParamOrNull("latitude") ?: throw RequestParamLostException("latitude is lost")
@@ -93,6 +95,45 @@ class ShopQueryHandler(
         val shopResponseList = satisfiedShopIdFlow
             .map { shopQueryService.findShopById(it)!! }
             .map { it.toSimpleResponse() } // 간략화된 shop 정보로 변환
+            .toList()
+
+        check(shopResponseList.isNotEmpty()) {
+            throw ShopNotFoundException("Shop is not found!!")
+        }
+
+        return@coroutineScope ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValueAndAwait(ResultFactory.getMultipleResult(shopResponseList))
+    }
+
+    // detail-category 기반의 반경 검색
+    suspend fun searchByDetailCategoryWithIn(request: ServerRequest): ServerResponse = coroutineScope {
+        val detailCategory = request.queryParamOrNull("detail-category") ?: throw RequestParamLostException("category is lost")
+        val latitude = request.queryParamOrNull("latitude") ?: throw RequestParamLostException("latitude is lost")
+        val longitude = request.queryParamOrNull("longitude") ?: throw RequestParamLostException("longitude is lost")
+        val distance = request.queryParamOrNull("distance") ?: throw RequestParamLostException("distance is lost")
+        val unit = request.queryParamOrNull("unit") ?: throw RequestParamLostException("unit is lost")
+        val page = request.queryParamOrNull("page") ?: throw RequestParamLostException("page is lost")
+        val size = request.queryParamOrNull("size") ?: throw RequestParamLostException("size is lost")
+
+        // Check the given detailCategory is valid
+        if(detailCategory !in DetailCategory.values().map { it.toString() }) {
+            throw DetailCategoryNotFoundException("detail-category is lost")
+        }
+
+        val satisfiedShopIdFlow = grpcShopSearchClient.searchDetailCategoryWithIn(
+            detailCategory,
+            latitude.toDouble(),
+            longitude.toDouble(),
+            distance.toDouble(),
+            unit,
+            page.toInt(),
+            size.toInt()
+        ).idsList.asFlow()
+
+        val shopResponseList = satisfiedShopIdFlow
+            .map { shopQueryService.findShopById(it)!! }
+            .map { it.toSimpleResponse() }
             .toList()
 
         check(shopResponseList.isNotEmpty()) {

--- a/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
+++ b/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
@@ -16,6 +16,7 @@ class ShopQueryRouter(
             GET("/simple", shopHandler::findById)
             GET("/simple/list", shopHandler::getAllShops)
             GET("/simple/list/category", shopHandler::searchByCategoryWithIn) // category 반경 검색
+            GET("/simple/list/detail-category", shopHandler::searchByDetailCategoryWithIn) // detailCategory 반경 검색
         }
     }
 }

--- a/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
+++ b/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
@@ -18,6 +18,7 @@ import reactor.core.publisher.Mono
 import team.bakkas.applicationquery.grpc.client.GrpcShopSearchClient
 import team.bakkas.common.exceptions.RequestParamLostException
 import team.bakkas.common.exceptions.shop.CategoryNotFoundException
+import team.bakkas.common.exceptions.shop.DetailCategoryNotFoundException
 import team.bakkas.common.exceptions.shop.ShopNotFoundException
 import team.bakkas.domainquery.service.ifs.ShopQueryService
 import team.bakkas.dynamo.shop.Shop
@@ -197,6 +198,73 @@ internal class ShopQueryHandlerUnitTest {
 
         // then
         shouldThrow<ShopNotFoundException> { shopQueryHandler.searchByCategoryWithIn(request) }
+    }
+
+    @Test
+    @DisplayName("[searchByDetailCategoryWithIn] 1. 유효하지 않은 detail category")
+    fun searchByDetailCategoryWithInTest1(): Unit = runBlocking {
+        // given
+        val detailCategory = "CAFE_BRAND"
+        val latitude = "0.0"
+        val longitude = "0.0"
+        val distance = "0.0"
+        val unit = "km"
+        val page = "0"
+        val size = "100"
+
+        val request = MockServerRequest.builder()
+            .queryParam("detail-category", detailCategory)
+            .queryParam("latitude", latitude)
+            .queryParam("longitude", longitude)
+            .queryParam("distance", distance)
+            .queryParam("unit", unit)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+
+        // then
+        shouldThrow<DetailCategoryNotFoundException> { shopQueryHandler.searchByDetailCategoryWithIn(request) }
+    }
+
+    @Test
+    @DisplayName("[searchByDetailCategoryWithIn] 2. detail category에 해당하는 shop이 존재하지 않는 경우")
+    fun searchByDetailCategoryWithInTest2(): Unit = runBlocking {
+        // given
+        val detailCategory = "CAFE_BREAD"
+        val latitude = "0.0"
+        val longitude = "0.0"
+        val distance = "0.0"
+        val unit = "km"
+        val page = "0"
+        val size = "100"
+
+        val request = MockServerRequest.builder()
+            .queryParam("detail-category", detailCategory)
+            .queryParam("latitude", latitude)
+            .queryParam("longitude", longitude)
+            .queryParam("distance", distance)
+            .queryParam("unit", unit)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+
+        coEvery {
+            grpcShopSearchClient.searchDetailCategoryWithIn(
+                detailCategory,
+                latitude.toDouble(),
+                latitude.toDouble(),
+                distance.toDouble(),
+                unit,
+                page.toInt(),
+                size.toInt()
+            )
+        } returns
+                SearchResponse.newBuilder()
+                    .addAllIds(listOf())
+                    .build()
+
+        // then
+        shouldThrow<ShopNotFoundException> { shopQueryHandler.searchByDetailCategoryWithIn(request) }
     }
 
     // MockServerRequest를 생성하는 메소드

--- a/commons/common/src/main/kotlin/team/bakkas/common/exceptions/shop/DetailCategoryNotFoundException.kt
+++ b/commons/common/src/main/kotlin/team/bakkas/common/exceptions/shop/DetailCategoryNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.bakkas.common.exceptions.shop
+
+/**
+ * @author Brian
+ * @since 2022/11/09
+ */
+class DetailCategoryNotFoundException(override val message: String) : RuntimeException(message) {
+}


### PR DESCRIPTION
## 변경 사항
### searchByDetailCategoryWithIn 메소드 추가 (가게의 세부 카테고리 기반 반경 검색 기능)
- Client Endpoint: http://localhost:10100/api/v2/shop/simple/list/detail-category?detail-category=?&latitude=?&longitude=?&distance=?&unit=?&page=?&size=?
- detail-category: 가게의 세부 카테고리
- latitude, longitude: 요청지의 위치 위도 경도 정보
- distance: 거리의 절댓값
- unit: 거리의 단위
- page: 페이지 정보
- size: 반환되는 가게의 개수
### Exceptions
- DetailCategoryNotFoundException : 가게 세부 카테고리를 잘못 넘겨주는 경우 발생
- ShopNotFoundException : 자신의 반경 내에 세부 정보에 해당하는 가게가 존재하지 않는 경우 발생