### PR TITLE
[ADD] shopQueryHandler의 searchByShopNameWithIn 추가

### DIFF
--- a/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
+++ b/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
@@ -17,6 +17,7 @@ class ShopQueryRouter(
             GET("/simple/list", shopHandler::getAllShops)
             GET("/simple/list/category", shopHandler::searchByCategoryWithIn) // category 반경 검색
             GET("/simple/list/detail-category", shopHandler::searchByDetailCategoryWithIn) // detailCategory 반경 검색
+            GET("/simple/list/shop-name", shopHandler::searchByShopNameWithIn) // 가게 이름 기반 검색
         }
     }
 }

--- a/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
+++ b/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
@@ -267,6 +267,63 @@ internal class ShopQueryHandlerUnitTest {
         shouldThrow<ShopNotFoundException> { shopQueryHandler.searchByDetailCategoryWithIn(request) }
     }
 
+    @Test
+    @DisplayName("[searchByShopNameWithIn] 1. 두 글자 미만으로 검색을 시도하는 경우")
+    fun searchByShopNameWithInTest1(): Unit = runBlocking {
+        // given
+        val shopName = "g"
+        val latitude = "0.0"
+        val longitude = "0.0"
+        val distance = "0.0"
+        val unit = "km"
+        val page = "0"
+        val size = "100"
+
+        val request = MockServerRequest.builder()
+            .queryParam("shop-name", shopName)
+            .queryParam("latitude", latitude)
+            .queryParam("longitude", longitude)
+            .queryParam("distance", distance)
+            .queryParam("unit", unit)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+
+        // then
+        shouldThrow<RequestParamLostException> { shopQueryHandler.searchByShopNameWithIn(request) }
+    }
+
+    @Test
+    @DisplayName("[searchByShopNameWithIn] 2. 가게가 존재하지 않는 경우")
+    fun searchByShopNameWithInTest2(): Unit = runBlocking {
+        // given
+        val shopName = "롯데리아"
+        val latitude = "0.0"
+        val longitude = "0.0"
+        val distance = "0.0"
+        val unit = "km"
+        val page = "0"
+        val size = "100"
+
+        val request = MockServerRequest.builder()
+            .queryParam("shop-name", shopName)
+            .queryParam("latitude", latitude)
+            .queryParam("longitude", longitude)
+            .queryParam("distance", distance)
+            .queryParam("unit", unit)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+
+        coEvery { grpcShopSearchClient.searchShopNameWithIn(shopName, latitude.toDouble(), longitude.toDouble(), distance.toDouble(), unit, page.toInt(), size.toInt()) } returns
+                SearchResponse.newBuilder()
+                    .addAllIds(listOf())
+                    .build()
+
+        // then
+        shouldThrow<ShopNotFoundException> { shopQueryHandler.searchByShopNameWithIn(request) }
+    }
+
     // MockServerRequest를 생성하는 메소드
     private inline fun generateRequest(block: () -> Mono<Any>): MockServerRequest {
         return MockServerRequest.builder()


### PR DESCRIPTION
## 변경 사항
### 가게 이름 기반의 반경 검색 구현 완료
- Client Endpoint: http://localhost:10100/api/v2/shop/simple/list/shop-name?shop-name=?&latitude=?&longitude=?&distance=?&unit=?&page=?&size=?
- shop-name: 가게의 이름, 부분 검색또한 지원한다
ex. 롯데리아 -> 롯데리아 영남대DT점
ex. 시그널 -> 버거시그널 영남대점
- latitude, longitude: 사용자가 전송한 위도, 경도 정보
- distance: 거리 정보
- unit: 거리의 단위
- page: 페이지 정보
- size: 반환하는 가게의 개수
### Exceptions
- RequestParamLostException: 가게의 이름을 1글자 이하로 제공하는 경우
- ShopNotFoundException: 가게를 찾아오지 못하는 경우. 즉, 가게가 존재하지 않는 경우