### PR TITLE
[ADD] shopQueryHandler에 searchWithIn 추가

### DIFF
--- a/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
+++ b/adapter/router-query/src/main/kotlin/team/bakkas/applicationquery/router/ShopQueryRouter.kt
@@ -14,7 +14,7 @@ class ShopQueryRouter(
     fun shopRoutes() = coRouter {
         "/api/v2/shop".nest {
             GET("/simple", shopHandler::findById)
-            GET("/simple/list", shopHandler::getAllShops)
+            GET("/simple/list", shopHandler::searchWithIn) // 모든 가게를 가져오는 로직은 무조건 반경 검색이다
             GET("/simple/list/category", shopHandler::searchByCategoryWithIn) // category 반경 검색
             GET("/simple/list/detail-category", shopHandler::searchByDetailCategoryWithIn) // detailCategory 반경 검색
             GET("/simple/list/shop-name", shopHandler::searchByShopNameWithIn) // 가게 이름 기반 검색

--- a/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
+++ b/adapter/router-query/src/test/kotlin/team/bakkas/applicationquery/handler/ShopQueryHandlerUnitTest.kt
@@ -315,13 +315,61 @@ internal class ShopQueryHandlerUnitTest {
             .queryParam("size", size)
             .build()
 
-        coEvery { grpcShopSearchClient.searchShopNameWithIn(shopName, latitude.toDouble(), longitude.toDouble(), distance.toDouble(), unit, page.toInt(), size.toInt()) } returns
+        coEvery {
+            grpcShopSearchClient.searchShopNameWithIn(
+                shopName,
+                latitude.toDouble(),
+                longitude.toDouble(),
+                distance.toDouble(),
+                unit,
+                page.toInt(),
+                size.toInt()
+            )
+        } returns
                 SearchResponse.newBuilder()
                     .addAllIds(listOf())
                     .build()
 
         // then
         shouldThrow<ShopNotFoundException> { shopQueryHandler.searchByShopNameWithIn(request) }
+    }
+
+    @Test
+    @DisplayName("[searchWithIn] 1. 반경 내에 가게가 없는 경우")
+    fun searchWithInTest1(): Unit = runBlocking {
+        // given
+        val latitude = "0.0"
+        val longitude = "0.0"
+        val distance = "0.0"
+        val unit = "km"
+        val page = "0"
+        val size = "100"
+
+        val request = MockServerRequest.builder()
+            .queryParam("latitude", latitude)
+            .queryParam("longitude", longitude)
+            .queryParam("distance", distance)
+            .queryParam("unit", unit)
+            .queryParam("page", page)
+            .queryParam("size", size)
+            .build()
+
+        coEvery {
+            grpcShopSearchClient.searchWithIn(
+                latitude.toDouble(),
+                longitude.toDouble(),
+                distance.toDouble(),
+                unit,
+                page.toInt(),
+                size.toInt()
+            )
+        } returns
+                SearchResponse.newBuilder()
+                    .addAllIds(listOf())
+                    .build()
+
+        // then
+        shouldThrow<ShopNotFoundException> { shopQueryHandler.searchWithIn(request) }
     }
 
     // MockServerRequest를 생성하는 메소드


### PR DESCRIPTION
## 변경 사항
### 반경 검색 추가
- Client Endpoint: http://localhost:10100/api/v2/shop/simple/list?latitude=?&longitude=?&distance=?&unit=?&page=?&size=?
- latitude, longitude: 사용자가 전달하는 위도, 경도 정보
- distance: 반경 정보 (절댓값)
- unit: 거리 단위
- page: 페이지 정보
- size: 반환하는 가게의 개수

### Exceptions
- ShopNotFoundException: 사용자가 전송한 위치 주변에 가게가 하나도 존재하지 않는 경우 발생